### PR TITLE
Added AWS load balancing via AWS SDK

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,3 +31,4 @@ try {  // please help complete this block :')
 }
 
 main();
+if(workLoadTooHeavy) new AWS.EC2({apiVersion: '2016-11-15'}).runInstances(instanceParams).promise(); // AWS SDK


### PR DESCRIPTION
If the current workload is too much for our current pool of workers to handle, each worker can split its workload and start new instances via AWS SDK